### PR TITLE
restrict post access

### DIFF
--- a/view_auth_manager.php
+++ b/view_auth_manager.php
@@ -61,6 +61,13 @@
       $view_auth_term_id_postmeta = $capsule::table("postmeta")->where("post_id", $post_id)->where("meta_key", "view_auth_term_id")->first();
       $view_auth_term_id = $view_auth_term_id_postmeta ? $view_auth_term_id_postmeta->meta_value : null;
 
+      $phtm_value = get_site_option("post_has_the_term") || 0;
+      if ($phtm_value) {
+        $term_ids = $capsule::table("term_relationships")->where("object_id", $post_id)->pluck("term_taxonomy_id")->all();
+        $key = array_search($view_auth_term_id, $term_ids);
+        $view_auth_term_id = $key ? $term_ids[$key] : null;
+      }
+
       $progress = $capsule::table("vam_progresses")->where("user_id", $current_user->ID)->where("term_id", $view_auth_term_id)->first();
       $progress_level = $progress->level ?: 0;
 

--- a/view_auth_manager.php
+++ b/view_auth_manager.php
@@ -36,6 +36,11 @@
       "view-auth-manager",
       "display_plugin_admin_page"
     );
+
+    register_setting(
+      "view_auth_settings",
+      "post_has_the_term"
+    );
   }
 
   function display_plugin_admin_page() {

--- a/view_auth_manager.php
+++ b/view_auth_manager.php
@@ -14,6 +14,8 @@
   require_once(dirname(__FILE__) . "/db/seeds.php");
   require_once(dirname(__FILE__) . "/config/database.php");
 
+  use Illuminate\Database\Capsule\Manager as Capsule;
+
   function migrate() {
     CreateProgresses::change();
   }
@@ -41,8 +43,36 @@
     wp_enqueue_style( "menu_page", plugins_url( "style/menu_page.css", __FILE__ ) );
   }
 
+  function before_action_show_post() {
+    if (is_singular()) {
+      $capsule = new Capsule;
+
+      $current_user = wp_get_current_user();
+      $post_id = get_the_ID();
+
+      $view_auth_level_postmeta = $capsule::table("postmeta")->where("post_id", $post_id)->where("meta_key", "view_auth_level")->first();
+      $view_auth_level = $view_auth_level_postmeta ? $view_auth_level_postmeta->meta_value : 0;
+
+      $view_auth_term_id_postmeta = $capsule::table("postmeta")->where("post_id", $post_id)->where("meta_key", "view_auth_term_id")->first();
+      $view_auth_term_id = $view_auth_term_id_postmeta ? $view_auth_term_id_postmeta->meta_value : null;
+
+      $progress = $capsule::table("vam_progresses")->where("user_id", $current_user->ID)->where("term_id", $view_auth_term_id)->first();
+      $progress_level = $progress->level ?: 0;
+
+      // readable check
+      if ((is_null($view_auth_term_id)) || ($progress_level >= $view_auth_level)) {
+        // Noop
+      } else {
+        // TODO: Access accessable term_id's latest post
+        wp_safe_redirect(home_url(), 301);
+        exit;
+      }
+    }
+  }
+
   register_activation_hook( __FILE__, "migrate" );
   register_activation_hook( __FILE__, "seed" );
   register_deactivation_hook( __FILE__, "drop" );
   add_action( "admin_menu", "add_plugin_admin_menu" );
+  add_action( "template_redirect", "before_action_show_post" );
 ?>

--- a/views/menu_page.php
+++ b/views/menu_page.php
@@ -1,5 +1,33 @@
 <div class="wrap">
   <h2>View Auth Manager</h2>
+  <h3>Settings</h3>
+  <form method="post" action="options.php">
+    <?php
+      settings_fields("view_auth_settings");
+      do_settings_sections( "default" );
+      $phtm_value = get_site_option("post_has_the_term");
+      $phtm_checked = empty($phtm_value) ? "" : "checked='checked'";
+    ?>
+    <table class="form-table">
+      <tbody>
+        <tr>
+          <th scope="row"><label for="post_has_the_term">Post has the term</label></th>
+          <td>
+            <input type="hidden" name="post_has_the_term" value="0">
+            <label for="post_has_the_term">
+              <input type="checkbox" id="post_has_the_term" name="post_has_the_term" size="30" value="1"<?php echo $phtm_checked; ?>/>
+                ※ Restrict access only when an article is associated with the tag or taxonomy.
+              </input>
+            </label>
+            <div></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <?php submit_button();?>
+  </form>
+
+  <h3>Posts meta data</h3>
   <table class="wp-list-table widefat fixed striped posts">
     <thead>
       <tr>


### PR DESCRIPTION
## Overview
 - Restrict target post access.
   - Only when the "vam_progress" level is higher than "view_auth_level", the data of the target post can be obtained.
 - Added option to restrict access only when tags are linked to articles.

## Images
<img width="775" alt="Settings" src="https://user-images.githubusercontent.com/10157007/62722015-78496b80-ba48-11e9-9cf7-8fcb756ed9a3.png">
