### PR TITLE
Add custom api

### DIFF
--- a/db/migrate/create_progresses.php
+++ b/db/migrate/create_progresses.php
@@ -3,7 +3,7 @@ use Illuminate\Database\Capsule\Manager as Capsule;
 
 class CreateProgresses
 {
-    public static function change()
+    public static function execute()
     {
         $capsule = new Capsule;
         $schema = $capsule->schema();

--- a/js/vam_authentication_options.js
+++ b/js/vam_authentication_options.js
@@ -1,0 +1,19 @@
+jQuery(function($) {
+  $("[data-action='vam-progress-level']").on("click", function(e) {
+    e.preventDefault();
+
+    const settings = VamAuthenticationSettings;
+
+    $.ajax({
+      url: "/wp-json/vam/v1/current/progresses",
+      method: "POST",
+      data: { post_id: settings.post_id },
+      beforeSend: function(xhr) {
+        xhr.setRequestHeader("X-WP-Nonce", settings.nonce);
+      }
+    }).done(function(response) {
+      console.log(response);
+      toastr.info(response["message"]);
+    });
+  });
+});

--- a/js/vam_authentication_options.js
+++ b/js/vam_authentication_options.js
@@ -13,7 +13,7 @@ jQuery(function($) {
       }
     }).done(function(response) {
       console.log(response);
-      toastr.info(response["message"]);
+      // toastr.info(response["message"]);
     });
   });
 });

--- a/view_auth_manager.php
+++ b/view_auth_manager.php
@@ -124,18 +124,20 @@ function set_toastr_for_general()
     wp_enqueue_script("toastr_redirected_js", plugins_url("js/toastr_redirected.js", __FILE__), array( "jquery" ), false, true);
 }
 
-function set_authentication_options() {
+function set_authentication_options()
+{
     if (is_singular()) {
-        wp_register_script("vam_authentication_options", plugins_url("js/vam_authentication_options.js", __FILE__), array ( "jquery" ), null, true);
+        wp_register_script("vam_authentication_options", plugins_url("js/vam_authentication_options.js", __FILE__), array( "jquery" ), null, true);
         wp_localize_script("vam_authentication_options", "VamAuthenticationSettings", array(
             "post_id" => get_the_ID(),
-            "nonce" => wp_create_nonce( "wp_rest" )
+            "nonce" => wp_create_nonce("wp_rest")
         ));
         wp_enqueue_script("vam_authentication_options");
     }
 }
 
-function add_custom_endpoint() {
+function add_custom_endpoint()
+{
     register_rest_route("vam/v1", "/current/progresses", array(
         "methods" => WP_REST_Server::EDITABLE,
         "permission_callback" => "is_readable_post_callback",
@@ -149,7 +151,8 @@ function add_custom_endpoint() {
     ));
 }
 
-function is_readable_post_callback($data) {
+function is_readable_post_callback($data)
+{
     $body = $data -> get_params();
     $current_user = wp_get_current_user();
     $current_user_id = $current_user->ID;
@@ -158,7 +161,8 @@ function is_readable_post_callback($data) {
 }
 
 // want private method
-function is_readable_post($post_id, $current_user_id) {
+function is_readable_post($post_id, $current_user_id)
+{
     $capsule = new Capsule;
 
     $view_auth_level_postmeta = $capsule::table("postmeta")->where("post_id", $post_id)->where("meta_key", "view_auth_level")->first();
@@ -180,7 +184,8 @@ function is_readable_post($post_id, $current_user_id) {
     return (is_null($view_auth_term_id)) || ($progress_level >= $view_auth_level);
 }
 
-function progress_level($data) {
+function progress_level($data)
+{
     $body = $data -> get_params();
     $capsule = new Capsule;
     $view_auth_level_postmeta = $capsule::table("postmeta")->where("post_id", $body["post_id"])->where("meta_key", "view_auth_level")->first();
@@ -199,7 +204,8 @@ function progress_level($data) {
                 [
                     "term_id" => $view_auth_term_id,
                     "user_id" => $current_user_id,
-                ], [
+                ],
+                [
                     "level" => $next_level,
                 ]
             );

--- a/view_auth_manager.php
+++ b/view_auth_manager.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Capsule\Manager as Capsule;
 
 function migrate()
 {
-    CreateProgresses::change();
+    CreateProgresses::execute();
 }
 
 function seed()
@@ -141,14 +141,13 @@ function set_toastr_for_general()
     wp_enqueue_script("toastr_redirected_js", plugins_url("js/toastr_redirected.js", __FILE__), array( "jquery" ), false, true);
 }
 
-add_action("wp_ajax_update_post_metadata", "update_post_metadata");
-add_action("wp_ajax_nopriv_update_post_metadata", "update_post_metadata");
-
 register_activation_hook(__FILE__, "migrate");
 register_activation_hook(__FILE__, "seed");
 register_deactivation_hook(__FILE__, "drop");
 add_action("admin_menu", "add_plugin_admin_menu");
 add_action("template_redirect", "before_action_show_post");
-add_action("admin_enqueue_scripts", "enqueue_vam_ajax_script");
-add_action("admin_enqueue_scripts", "set_toastr_for_admin");
 add_action("wp_enqueue_scripts", "set_toastr_for_general");
+add_action("admin_enqueue_scripts", "set_toastr_for_admin");
+add_action("admin_enqueue_scripts", "enqueue_vam_ajax_script");
+add_action("wp_ajax_update_post_metadata", "update_post_metadata");
+add_action("wp_ajax_nopriv_update_post_metadata", "update_post_metadata");


### PR DESCRIPTION
## Overview
 - Add custom API (endpoint) 
 - Only the user who is logged in is able to use the API.
 - You can call the API when you push the element with `data-action: "vam-progress-level"` in the post (is_singular is `true`) page.
 - The API enable to increment by 1 to  the `vam_progresses` level column.
   - The `user_id` is reffered to logging in user.
   - The `term_id` is reffered to the post's `vam_auth_term_id`.

## New endpoint document
### Endpoint
`/wp-json/vam/v1/current/progresses`

### Body params
`post_id` (integer) **required**

## Images
**※ Actually toast is not displayed**

![levelup](https://user-images.githubusercontent.com/10157007/63035928-03b67700-bef7-11e9-8c76-a0a12ebe3d63.gif)
